### PR TITLE
Fix parallel execution: replace PyRosettaCluster with Client.map() fo…

### DIFF
--- a/PatchMAN_protocol_dask.py
+++ b/PatchMAN_protocol_dask.py
@@ -4,6 +4,7 @@ from bin.dask_protocol_utils import *
 from dask.distributed import Client, LocalCluster, as_completed
 from dask import delayed
 import subprocess
+import sys
 import os
 
 def main():
@@ -33,7 +34,7 @@ def main():
 	pdb_list_file = "motif_list"
 	if 1 in args.steps_range:
 		print("Step 1: Splitting to motifs...")
-		results_split_to_motifs = subprocess.run(['python3', f"{os.environ['BIN_DIR']}/split_to_motifs.py", "-i", receptor,
+		results_split_to_motifs = subprocess.run([sys.executable, f"{os.environ['BIN_DIR']}/split_to_motifs.py", "-i", receptor,
 						*args.focus_mask_args.split()], check=True)
 		
 		check_subprocess_result(results_split_to_motifs, 1)
@@ -52,7 +53,7 @@ def main():
 
 		clean_pdbs = glob.glob("*.clean.pdb")
 		if clean_pdbs:
-			result_prepack = subprocess.run(['python3', f"{os.environ['BIN_DIR']}/prepack_receptor.py", clean_pdbs[0]],
+			result_prepack = subprocess.run([sys.executable, f"{os.environ['BIN_DIR']}/prepack_receptor.py", clean_pdbs[0]],
 									capture_output=True, text=True)
 			
 			check_subprocess_result(result_prepack, 2)
@@ -105,7 +106,7 @@ def main():
 		print(f"FPD called with arguments: {' '.join(args.fpd_args)}")
 		
 		# Run FlexPepDock Python script directly (using PROTOCOL_ROOT path like original)
-		fpd_cmd = ' '.join(['python3', f"{os.environ['PROTOCOL_ROOT']}/bin/fpd.py"] + args.fpd_args)
+		fpd_cmd = ' '.join([sys.executable, f"{os.environ['PROTOCOL_ROOT']}/bin/fpd.py"] + args.fpd_args)
 		
 		# Create the process
 		fpd_process = subprocess.Popen(fpd_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
@@ -132,7 +133,8 @@ def main():
 		os.makedirs("clustering", exist_ok=True)
 
 		# Run clustering Python script and redirect output to clog file
-		cluster_cmd = ['python3', f"{os.environ['PROTOCOL_ROOT']}/bin/cluster.py"]
+		cluster_cmd = [sys.executable, f"{os.environ['PROTOCOL_ROOT']}/bin/cluster.py",
+		               '-c', str(args.cpu)]
 
 		with open("clustering/clog", "w") as clog_file:
 			cluster_result = subprocess.run(cluster_cmd, stdout=clog_file, stderr=subprocess.STDOUT, text=True)

--- a/bin/cluster.py
+++ b/bin/cluster.py
@@ -22,8 +22,12 @@ from pyrosetta.rosetta.core.scoring import superimpose_pose, gdtha
 from pyrosetta.rosetta.protocols.cluster import ClusterPhilStyle
 from pyrosetta.rosetta.std import map_core_id_AtomID_core_id_AtomID
 
+from protocol_utils import get_available_cpus
+
 import warnings
 warnings.filterwarnings("ignore", category=UserWarning)
+
+INIT_OPTIONS = '-mute FlexPepDockingProtocol FlexPepDockingPoseMetrics protocols.flexPepDocking core.pack core.scoring basic.io.database'
 
 
 def create_fpd_scoring_mover(native_pose):
@@ -57,44 +61,110 @@ def create_fpd_scoring_mover(native_pose):
 
         return fpd_protocol
 
-def rescore_models(silent_file, scores_sorted, tags=None, output_file='rescore.sc'):
+def _init_rescore_worker(silent_file, top_scoring_tag, init_options):
+    """Initializer for multiprocessing.Pool workers: init PyRosetta and create scoring mover once."""
+    import pyrosetta
+    pyrosetta.init(init_options)
+    global _scoring_mover, _silent_file
+    native_pose = read_poses_from_silentfile(silent_file, tags=[top_scoring_tag])[0]
+    _scoring_mover = create_fpd_scoring_mover(native_pose)
+    _silent_file = silent_file
+
+
+def _rescore_task(tag):
+    """Score a single pose in a worker process."""
     from pyrosetta.rosetta.protocols.jd2 import get_string_real_pairs_from_current_job
-    # Remove old RMSD columns
-    rms_columns = [col for col in scores_sorted.columns if col.startswith('rms')]
-    scores_filtered = scores_sorted.drop(columns=rms_columns)
+
+    pose = read_poses_from_silentfile(_silent_file, tags=[tag])[0]
+    _scoring_mover.apply(pose)
+
+    extra_scores = dict(get_string_real_pairs_from_current_job())
+    extra_scores['description'] = tag
+
+    for score_type in ['score', 'fa_atr', 'fa_rep', 'fa_sol', 'fa_dun', 'hbond_sc']:
+        extra_scores[score_type] = pose.scores[score_type]
+
+    return {'task_id': tag, 'returncode': 0, 'scores': extra_scores}
+
+
+def rescore_models(silent_file, scores_sorted, tags=None, output_file='rescore.sc', num_cpus=None):
+    # Get all tags from score data (no PyRosetta needed)
+    all_tags = scores_sorted.description.tolist()
 
     # Prepare top scoring decoy
     top_scoring_tag = scores_sorted.head(1).description.iloc[0]
-    top_scoring_pose = read_poses_from_silentfile(silent_file, tags=[top_scoring_tag], sort_by_score='reweighted_sc')[0]
 
-    poses = read_poses_from_silentfile(silent_file)
-    fpd_scoring_mover = create_fpd_scoring_mover(top_scoring_pose)
+    # Determine number of CPUs
+    if num_cpus is None:
+        num_cpus = get_available_cpus()
+    num_cpus = min(num_cpus, len(all_tags))
 
-    #Rescore
-    scores_to_save = ['rmsALL', 'rmsALL_allIF', 'rmsALL_if', 'rmsBB', 'rmsBB_allIF', 'rmsBB_if', 
-                      'rmsSC_allIF', 'rmsPHIPSI', 'rmsPHIPSI', 'rmsPHIPSI_if', 'rmsCA', 'rmsCA_if']
     more_scores_to_save = ['score', 'fa_atr', 'fa_rep', 'fa_sol', 'fa_dun', 'hbond_sc']
-    scores = []
-    all_poses = []
-    for pose in poses:
-        tag = pyrosetta.rosetta.core.pose.tag_from_pose(pose)
-        
-        # before = pose.scores['rmsBB_if'] # debug
-        fpd_scoring_mover.apply(pose)
-        extra_scores = dict(get_string_real_pairs_from_current_job())
-        extra_scores['description'] = tag
-                
-        # we also need them in the poses we work with, otherwise the final results will contain the old values
-        if tag in tags:
-            for k, v in extra_scores.items():
-                if not k.startswith('best'):
-                    pose.scores[k] = v
-            all_poses.append(pose)
 
-        # we want to also provide these, but these are not from FPD
-        for score_type in more_scores_to_save:
-            extra_scores[score_type] = pose.scores[score_type]
-        scores.append(extra_scores)
+    if num_cpus > 1:
+        # Parallel rescoring with multiprocessing.Pool — avoids Dask nanny killing
+        # workers during long C++ FPD scoring calls that block heartbeats
+        import multiprocessing
+        print(f"Parallel rescoring with {num_cpus} workers for {len(all_tags)} poses")
+
+        ctx = multiprocessing.get_context('spawn')
+        pool = ctx.Pool(num_cpus, initializer=_init_rescore_worker,
+                        initargs=(silent_file, top_scoring_tag, INIT_OPTIONS))
+        results = pool.map(_rescore_task, all_tags)
+        pool.close()
+        pool.join()
+
+        # Build score dicts from results
+        score_lookup = {}
+        scores = []
+        for result in results:
+            score_dict = result['scores']
+            scores.append(score_dict)
+            score_lookup[score_dict['description']] = score_dict
+
+        # Now safe to init PyRosetta in the main process (pool workers are gone)
+        pyrosetta.init(INIT_OPTIONS)
+
+        # Read only the tags we need for clustering, patch their scores
+        all_poses = []
+        for tag in tags:
+            pose = read_poses_from_silentfile(silent_file, tags=[tag])[0]
+            if tag in score_lookup:
+                for k, v in score_lookup[tag].items():
+                    if not k.startswith('best'):
+                        try:
+                            pose.scores[k] = v
+                        except ValueError:
+                            pass  # skip reserved energy names (fa_atr etc.)
+            all_poses.append(pose)
+    else:
+        # Sequential fallback — no workers, safe to init in main process
+        pyrosetta.init(INIT_OPTIONS)
+        print(f"Sequential rescoring for {len(all_tags)} poses")
+        top_scoring_pose = read_poses_from_silentfile(silent_file, tags=[top_scoring_tag], sort_by_score='reweighted_sc')[0]
+        poses = read_poses_from_silentfile(silent_file)
+        fpd_scoring_mover = create_fpd_scoring_mover(top_scoring_pose)
+
+        scores = []
+        all_poses = []
+        for pose in poses:
+            tag = pyrosetta.rosetta.core.pose.tag_from_pose(pose)
+
+            fpd_scoring_mover.apply(pose)
+            extra_scores = dict(get_string_real_pairs_from_current_job())
+            extra_scores['description'] = tag
+
+            # we also need them in the poses we work with, otherwise the final results will contain the old values
+            if tag in tags:
+                for k, v in extra_scores.items():
+                    if not k.startswith('best'):
+                        pose.scores[k] = v
+                all_poses.append(pose)
+
+            # we want to also provide these, but these are not from FPD
+            for score_type in more_scores_to_save:
+                extra_scores[score_type] = pose.scores[score_type]
+            scores.append(extra_scores)
 
     # Save calculated RMSD-s
     rescore_df = pd.DataFrame(scores).sort_values(by='reweighted_sc', ascending=True)
@@ -559,14 +629,14 @@ def parse_args():
     parser.add_argument("-t", "--tags_to_remove", nargs="+", default=[], help="Tags to exclude from clustering.")
     parser.add_argument("-r", "--radius", type=float, default=2.0, help="RMSD threshold for clustering.")
     parser.add_argument("-x", "--topX", type=int, default=0.01, help="Ratio of decoys to take for clustering (0<x<=1) or exact number x>1")
+    parser.add_argument("-c", "--cpus", type=int, default=None,
+                        help="Number of CPUs for parallel rescoring. Default: all available.")
     parser.add_argument("--no-rescore", action="store_true", help="Do not rescore against top scoring structure.")
 
     return parser.parse_args()
 
 
 def main():
-    pyrosetta.init('-mute FlexPepDockingProtocol FlexPepDockingPoseMetrics protocols.flexPepDocking core.pack core.scoring basic.io.database')
-
     args = parse_args()
 
     if not os.path.isdir(args.work_dir):
@@ -591,9 +661,11 @@ def main():
     tags = filter_and_select_top_structures(scores_sorted, tags_to_remove=args.tags_to_remove, topX=args.topX).description.tolist()
 
     if not args.no_rescore:
-        scores_sorted, all_poses = rescore_models(args.silent_file, scores_sorted, tags, output_file='rescore.sc')
+        scores_sorted, all_poses = rescore_models(args.silent_file, scores_sorted, tags,
+                                                     output_file='rescore.sc', num_cpus=args.cpus)
         scores_sorted.to_csv('sorted.sc', sep='\t', index=False, header=False)
     else:
+        pyrosetta.init(INIT_OPTIONS)
         all_poses = read_poses_from_silentfile(args.silent_file, tags)
     actual_radius = calculate_actual_radius(all_poses[0], args.radius)
 

--- a/bin/cluster.sh
+++ b/bin/cluster.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 #SBATCH --time=24:00:00
-#SBATCH --mem=2000m
+#SBATCH --cpus-per-task=20
+#SBATCH --mem-per-cpu=2G
+#SBATCH --nodes=1
 #SBATCH --get-user-env
 
 mkdir -p clustering/
-python3 "$PROTOCOL_ROOT/bin/cluster.py" > clustering/clog
+python3 "$PROTOCOL_ROOT/bin/cluster.py" -c ${SLURM_CPUS_PER_TASK:-1} > clustering/clog 2>&1

--- a/bin/dask_protocol_utils.py
+++ b/bin/dask_protocol_utils.py
@@ -5,9 +5,11 @@ from datetime import datetime
 
 cluster = None  # Global variable to hold the Dask cluster instance
 
-def run_dask_tasks(cluster, task_func, task_args_list, task_name):
+def run_dask_tasks(cluster, task_func, task_args_list, task_name, plugin=None, collect_results=False):
 	"""Execute tasks using Dask cluster and monitor progress"""
 	client = Client(cluster.scheduler_address)
+	if plugin:
+		client.register_plugin(plugin)
 
 	print(f"Starting {task_name} with {len(task_args_list)} tasks")
 	print(f"Dask dashboard: {client.dashboard_link}")
@@ -21,11 +23,14 @@ def run_dask_tasks(cluster, task_func, task_args_list, task_name):
 	# Process results as they complete
 	completed_count = 0
 	failed_tasks = []
+	all_results = [] if collect_results else None
 
 	for future in as_completed(futures):
 		try:
 			result = future.result()
 			completed_count += 1
+			if collect_results:
+				all_results.append(result)
 
 			# Create individual log file for this task
 			task_id = result.get('task_id', 'unknown')
@@ -78,19 +83,23 @@ def run_dask_tasks(cluster, task_func, task_args_list, task_name):
 
 	if failed_tasks:
 		print(f"Warning: {len(failed_tasks)} tasks failed in {task_name}")
+		if collect_results:
+			return False, all_results
 		return False
 	else:
 		print(f"All {task_name} tasks completed successfully")
+		if collect_results:
+			return True, all_results
 		return True
 
-def setup_cluster(n_searches, cpu_count):
+def setup_cluster(n_searches, cpu_count, memory_limit='500MB'):
 	"""Get existing cluster or create new one if needed"""
 	global cluster
 	if cluster is None:
 		cluster = LocalCluster(
 			n_workers=min(cpu_count, n_searches),
 			threads_per_worker=1,
-			memory_limit='500MB',
+			memory_limit=memory_limit,
 			dashboard_address=':8787'
 		)
 		print(f"Created Dask cluster with {cluster.workers} workers")

--- a/bin/fpd.py
+++ b/bin/fpd.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pyrosetta
 from dask_jobqueue import SLURMCluster
 from pyrosetta import *
-from dask.distributed import Client, WorkerPlugin
+from dask.distributed import Client, LocalCluster, WorkerPlugin
 
 
 class PyRosettaFPDPlugin(WorkerPlugin):
@@ -30,14 +30,14 @@ class PyRosettaFPDPlugin(WorkerPlugin):
 		worker.fpd_min_rec_bb = self.min_rec_bb
 		worker.fpd_native_path = self.native_path
 		
-		# For SLURM: Initialize once per worker (the old way)
-		print(f"Initializing PyRosetta ONCE on SLURM worker {worker.id}")
+		# Initialize once per worker
+		print(f"Initializing PyRosetta ONCE on worker {worker.id}")
 		pyrosetta.init(self.init_options)
-		
+
 		# Create the FPD mover once
 		fpd_mover = self._create_fpd_mover()
 		worker.fpd_mover = fpd_mover
-		print(f"PyRosetta and FlexPepDock initialized on SLURM worker {worker.id}")
+		print(f"PyRosetta and FlexPepDock initialized on worker {worker.id}")
 		
 		sys.stdout.flush()
 	
@@ -333,6 +333,52 @@ def run_fpd_cluster_local(list_of_inputs, init_opts, min_rec_bb=False, output_pa
 		outfile.writelines(score_lines)
 
 
+def run_fpd_cluster_local_direct(list_of_inputs, init_opts, min_rec_bb=False, output_path='.',
+                                  nstruct=1, finished_decoys=None, native_path=None, cpu=None):
+	"""
+	Run FPD locally using LocalCluster + Client.map() + PyRosettaFPDPlugin.
+	Reuses the SLURM task functions (protocol_slurm, create_tasks_slurm,
+	write_score_file_from_silent) with a local Dask cluster instead of SLURMCluster.
+	This avoids the PyRosettaCluster billiard subprocess overhead and the pickle.dumps()
+	hang that can occur with dry_run=True.
+	"""
+	import psutil
+
+	cpu = cpu if cpu else len(psutil.Process().cpu_affinity())
+	print(f"Running FlexPepDock locally on {len(list_of_inputs)} inputs with {cpu} workers")
+
+	# Each worker handles 1 task at a time; parallelism is across workers, not threads
+	init_opts = init_opts + " -multithreading:total_threads 1" + " -out:level 300"
+
+	pyrosetta.distributed.init(init_opts)
+
+	# Create task list (reuse SLURM task creation with resume support)
+	task_args = create_tasks_slurm(list_of_inputs, nstruct, output_path, finished_decoys)
+
+	if not task_args:
+		print("No tasks to run.")
+		return
+
+	# LocalCluster: 1 process per CPU, 1 thread per process (PyRosetta is not thread-safe)
+	cluster = LocalCluster(n_workers=cpu, threads_per_worker=1, processes=True)
+	client = Client(cluster)
+	print(f"Dask dashboard: {client.dashboard_link}")
+
+	try:
+		# Init PyRosetta and create FPD mover once per worker
+		client.register_plugin(PyRosettaFPDPlugin(init_opts, min_rec_bb, native_path))
+
+		# Submit all tasks and wait for completion
+		futures = [client.submit(protocol_slurm, *args) for args in task_args]
+		client.gather(futures)
+
+		print("All tasks completed. Combining silent files and extracting scores...")
+		write_score_file_from_silent(output_path)
+	finally:
+		client.close()
+		cluster.close()
+
+
 def create_fpd_mover(min_rec_bb=False, native_path=None):
 	"""Helper method to create FPD mover"""
 	import pyrosetta.distributed.io as io
@@ -519,6 +565,8 @@ def main():
 						default=os.getcwd())
 	parser.add_argument("--use_local", action="store_true",
 						help="Use LocalCluster instead of SLURMCluster. Default: False")
+	parser.add_argument("--legacy_local", action="store_true",
+						help="With --use_local, use legacy PyRosettaCluster path instead of Client.map(). Default: False")
 	args = parser.parse_args()
 	
 	# Collect input files
@@ -533,8 +581,9 @@ def main():
 	# For init Rosetta
 	init_opts = create_init_opts(args)
 	
-	# Clean up existing output files before running FlexPepDockcd
-	if not args.use_local: # PyRosettaCluster writes directly into a silent file, so no need to clean up
+	# Clean up existing output files before running FlexPepDock
+	# Only the legacy PyRosettaCluster path writes directly into a silent file; skip cleanup for it
+	if not (args.use_local and args.legacy_local):
 		clean_before_run(args.force_rerun)
 	
 	# If we did not want to force rerunning and there are some decoys already finished, we need to list them
@@ -547,8 +596,12 @@ def main():
 	# Run FlexPepDock
 	print('Running FlexPepDock...')
 	if args.use_local:
-		run_fpd_cluster_local(input_files, init_opts, args.min_rec_bb, args.outdir, nstruct,
-							  finished_decoys, args.native, args.cpu)
+		if args.legacy_local:
+			run_fpd_cluster_local(input_files, init_opts, args.min_rec_bb, args.outdir, nstruct,
+								  finished_decoys, args.native, args.cpu)
+		else:
+			run_fpd_cluster_local_direct(input_files, init_opts, args.min_rec_bb, args.outdir, nstruct,
+										  finished_decoys, args.native, args.cpu)
 	else:
 		run_fpd_cluster_slurm(input_files, init_opts, args.min_rec_bb, args.outdir, nstruct,
 					finished_decoys, args.native)

--- a/bin/protocol_utils.py
+++ b/bin/protocol_utils.py
@@ -9,6 +9,11 @@ import configparser
 import socket
 import glob
 
+def get_available_cpus():
+	"""Get number of available CPUs, respecting SLURM cgroups."""
+	return len(os.sched_getaffinity(0))
+
+
 def load_config(config_file_path="config.ini"):
 	'''
 	Load the configuration file and set up environment variables
@@ -187,7 +192,7 @@ def parse_protocol_args():
 	
 	# get the number of cpu-s
 	if args.cpu is None:
-		args.cpu = len(os.sched_getaffinity(0))
+		args.cpu = get_available_cpus()
 	
 	# also validate working directory and create if it doesn't exist
 	try:


### PR DESCRIPTION
…r FPD, multiprocessing.Pool for rescoring

- fpd.py: Add run_fpd_cluster_local_direct() using LocalCluster + Client.map()
  + WorkerPlugin, avoiding PyRosettaCluster's billiard subprocess pickle.dumps() hang. Old path preserved via --legacy_local flag.
- cluster.py: Replace Dask-based rescoring with multiprocessing.Pool (spawn context) to avoid nanny killing workers during long C++ FPD scoring calls that block heartbeats. Defer pyrosetta.init() in main process until after pool workers finish.
- cluster.sh: Increase SLURM allocation to 20 CPUs for parallel rescoring, add --nodes=1 to keep on single node.
- PatchMAN_protocol_dask.py: Use sys.executable instead of hardcoded 'python3' for subprocess calls to respect conda environment.